### PR TITLE
Fix wrong return types in TestingCommandBus class

### DIFF
--- a/src/Implementation/CommandBus/TestingCommandBus.php
+++ b/src/Implementation/CommandBus/TestingCommandBus.php
@@ -90,7 +90,7 @@ class TestingCommandBus implements CommandBus
         return $this->getAt(0);
     }
 
-    public function firstWithClass(string $className): int
+    public function firstWithClass(string $className)
     {
         foreach ($this->commands as $command) {
             if (\get_class($command) === $className) {
@@ -101,7 +101,7 @@ class TestingCommandBus implements CommandBus
         throw new \InvalidArgumentException(\sprintf("There is no command with class %s", $className));
     }
 
-    public function firstInstanceOf(string $className): int
+    public function firstInstanceOf(string $className)
     {
         foreach ($this->commands as $command) {
             if ($command instanceof $className) {

--- a/src/Implementation/EventBus/TestingEventBus.php
+++ b/src/Implementation/EventBus/TestingEventBus.php
@@ -88,7 +88,7 @@ class TestingEventBus implements EventBus
         return $this->getAt(0);
     }
 
-    public function firstWithClass(string $className): int
+    public function firstWithClass(string $className)
     {
         foreach ($this->events as $event) {
             if (\get_class($event) === $className) {
@@ -99,7 +99,7 @@ class TestingEventBus implements EventBus
         throw new \InvalidArgumentException(\sprintf("There is no event with class %s", $className));
     }
 
-    public function firstInstanceOf(string $className): int
+    public function firstInstanceOf(string $className)
     {
         foreach ($this->events as $event) {
             if ($event instanceof $className) {


### PR DESCRIPTION
Like `getAt()` or `first()` methods, `firstWithClass()` and ` firstInstanceOf()` should not specified any return type.

The `int` type specified currently seems to be a copy-paste error.